### PR TITLE
Fixes bug when loading persisted queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If a *uniqueness* expression is set, then each queue will only contain signals t
 
 A negative *interval* means that signals will not be emitted at any interval. Instead, the *emit* command is the only way for the block to notify signals.
 
-Uses persistance to maintain queues between stopping and starting of the block.
+Uses persistance to maintain queues between stopping and starting of the block. If the *capacity* is configured smaller than the the persisted queues, then signals are removed from the back of the queue during block configure to get the queues down to the current configured capacity.
 
 Properties
 --------------

--- a/queue_block.py
+++ b/queue_block.py
@@ -197,9 +197,12 @@ class Queue(GroupBy, Block):
 
     def _load(self):
         prev_queues = self.persistence.load('queues')
-        # if persisted dictonary is not defaultdict, convert it
         if prev_queues:
+            # If persisted dictonary is not defaultdict, convert it
             self._queues = defaultdict(list, prev_queues)
+            # Make sure perisisted queue capacity is less than current config
+            for queue_name, queue_values in self._queues.items():
+                self._queues[queue_name] = queue_values[:self.capacity]
         # build _groups for groupby mixin
         self._groups = list(self._queues.keys())
 


### PR DESCRIPTION
Fix #18.
Make sure perisisted queue capacity is less than current config.